### PR TITLE
Fix missing COMBINED_OUTPUT variable in run script

### DIFF
--- a/Taskfile
+++ b/Taskfile
@@ -1,3 +1,3 @@
-default: QUAST_OUT="combined_quast_output" && COMBINED_OUTPUT=${WORK_DIR}/${QUAST_OUT} && python /usr/local/quast/quast.py $LABELS $REFERENCES --threads `nproc` --output-dir ${COMBINED_OUTPUT} $CONTIGS  
-metaquast-default: QUAST_OUT="combined_reference" && COMBINED_OUTPUT=${WORK_DIR}/${QUAST_OUT} && python /usr/local/quast/metaquast.py $LABELS $REFERENCES --threads `nproc` --output-dir $WORK_DIR $CONTIGS  
-metaquast-scaffold: QUAST_OUT="combined_reference" && COMBINED_OUTPUT=${WORK_DIR}/${QUAST_OUT} && python /usr/local/quast/metaquast.py $LABELS $REFERENCES --threads `nproc` --scaffolds --output-dir $WORK_DIR $CONTIGS  
+default: quast "combined_quast_output" "quast.py"
+metaquast-default: quast "combined_reference" "metaquast.py"
+metaquast-scaffold: quast "combined_reference" "metaquast.py"

--- a/run
+++ b/run
@@ -54,11 +54,16 @@ if [ ! -z "$CACHE" ]; then
         WORK_DIR=$CACHE
 fi
 
-eval ${CMD}
+quast() {
+	set -o nounset
+	local QUAST_OUT=$1
+	local QUAST_VERSION=$2
+	local COMBINED_OUTPUT=${WORK_DIR}/${QUAST_OUT}
 
-cp  -r "${COMBINED_OUTPUT}" $OUTPUT
+	python /usr/local/quast/${QUAST_VERSION} ${LABELS} ${REFERENCES} --threads `nproc` --output-dir ${COMBINED_OUTPUT} ${CONTIGS}
+	cp  -r ${COMBINED_OUTPUT} ${OUTPUT}
 
-cat << EOF > ${OUTPUT}/biobox.yaml
+	cat << EOF > ${OUTPUT}/biobox.yaml
 version: 0.9.0
 results:
   - name: HTML
@@ -67,4 +72,8 @@ results:
     value: ${QUAST_OUT}/report.html
     description: A summary of multiple metrics.
 EOF
+
+}
+
+eval ${CMD}
 chmod -R a+rw  "${OUTPUT}"


### PR DESCRIPTION
The variable COMBINED_OUTPUT is missing in the `run` script because it is create in a subprocess and not exported to the global process. This PR fixes this by running quast in a bash function.
